### PR TITLE
Fix promise resolve function name

### DIFF
--- a/index.js
+++ b/index.js
@@ -414,7 +414,7 @@ var SeleniumGridInstance = function (name, args, logger, baseLauncherDecorator,
       return new Promise((startPromiseResolve, startPromiseReject) => {
         this._stopSession(end, err).then(() => {
           clearInterval(killInterval);
-          resolve('shutting down');
+          startPromiseResolve('shutting down');
           startPromiseReject('shutting down');
         });
       });


### PR DESCRIPTION
Error Message: 
```
01 08 2019 13:38:28.765:INFO [SeleniumGrid]: Killed chrome-mac1011.
(node:84022) UnhandledPromiseRejectionWarning: ReferenceError: resolve is not defined
    at _stopSession.then (/Users/mapengel/Documents/workspace/Kandy.js/node_modules/karma-selenium-grid-launcher/index.js:417:11)
```

Issue: 
Had an issue where one of my selenium grid launcher tests was crashing because `stopSession` was looking for `resolve()` but it was undefined. Based on the code and the error message we can clearly see that the resolve() function is not in scope and is improperly named likely due to a refactor.

Resolution:
Call the correct resolve function instead.